### PR TITLE
Add GHA Workflow for Publishing image to GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+name: Build and Publish Container
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+      - aws-lambda-v2.11
+      - v*
+
+jobs:
+  build-webui:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build webui
+        run: |
+          make clean-webui generate-webui
+          tar czvf webui.tar.gz ./webui/static/
+      - name: Artifact webui
+        uses: actions/upload-artifact@v3
+        with:
+          name: webui.tar.gz
+          path: webui.tar.gz
+  publish:
+    name: Build & Push Container
+    runs-on: ubuntu-latest
+    if: github.repository == 'linuxfoundation/traefik'
+    environment: development
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CGO_ENABLED: 0
+    needs:
+      - build-webui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Artifact webui
+        uses: actions/download-artifact@v3
+        with:
+          name: webui.tar.gz
+      - name: Untar webui
+        run: tar xvf webui.tar.gz
+      - name: Build
+        run: make binary
+      - name: Login to Registry
+        id: login-ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Set Container Metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'aws-lambda-v2.11') }}
+            type=ref,event=tag
+            type=sha
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.description=Traefik (LFX Fork)
+      - name: Build & Push Traefik Container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          build-args: TARGETPLATFORM=linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true


### PR DESCRIPTION
Build the binary and container and publishes the image to GHCR as linuxfoundation/traefik
