### PR TITLE
Trigger LFX Gateway Deployments for new Containers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,3 +82,23 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
+  trigger-deploy:
+    name: Trigger New Deployment
+    runs-on: ubuntu-latest
+    if: github.repository == 'linuxfoundation/traefik'
+    needs:
+      - publish
+    steps:
+      - name: Trigger LFX Gateway Deployment
+        run: |
+          repo_owner=linuxfoundation
+          repo_name=lfx-gateway
+          event_type=container_published
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+            -d "{\"event_type\": \"$event_type\"}"


### PR DESCRIPTION
Triggers a deployment of the lfx-gateway when a new version of the
traefik container is published.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
