### PR TITLE
AWS Lambda: Include Body if Invalid Status Code

### DIFF
--- a/pkg/middlewares/awslambda/aws_lambda.go
+++ b/pkg/middlewares/awslambda/aws_lambda.go
@@ -203,7 +203,7 @@ func (a *awsLambda) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Validate StatusCode before writing
 	if !(resp.StatusCode >= 100 && resp.StatusCode < 600) {
-		msg := fmt.Sprintf("Invalid response status code: %d", resp.StatusCode)
+		msg := fmt.Sprintf("Invalid response. Status Code: %d; Body: %s", resp.StatusCode, body)
 		logger.Error(msg)
 		tracing.SetErrorWithEvent(req, msg)
 


### PR DESCRIPTION
If there's an invalid status code response from Lambda, include the
response body as well in the trace. This should help with debugging why
the response failed.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
