### PR TITLE
AWS Lambda: Update Lambda Response Error Handling

### DIFF
--- a/pkg/middlewares/awslambda/aws_lambda.go
+++ b/pkg/middlewares/awslambda/aws_lambda.go
@@ -281,7 +281,6 @@ func bodyToBase64(req *http.Request) (bool, string, error) {
 }
 
 func (a *awsLambda) invokeFunction(ctx context.Context, request events.APIGatewayProxyRequest) (*events.APIGatewayProxyResponse, error) {
-
 	payload, err := json.Marshal(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)

--- a/pkg/middlewares/awslambda/aws_lambda_test.go
+++ b/pkg/middlewares/awslambda/aws_lambda_test.go
@@ -23,7 +23,6 @@ import (
 func setup(t *testing.T, response string) (*httptest.Server, http.Handler, *http.Request) {
 	t.Helper()
 	mockserver := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-
 		var buf bytes.Buffer
 		_, err := io.Copy(&buf, req.Body)
 		if err != nil {

--- a/pkg/middlewares/awslambda/aws_lambda_test.go
+++ b/pkg/middlewares/awslambda/aws_lambda_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 // Setup provides a mockserver (lambda handler), and should be closed
-// with 'defer func() { mockserver.Close() }()' once recieved
+// with 'defer func() { mockserver.Close() }()' once received
 func setup(t *testing.T, response string) (*httptest.Server, http.Handler, *http.Request) {
+	t.Helper()
 	mockserver := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 
 		var buf bytes.Buffer
@@ -198,7 +199,7 @@ func Test_AWSLambdaMiddleware_bodyToBase64_notEncodedJSON(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// Test_AWSLambdaMiddleware_bodyToBase64_notEncodedJSON
+// Test_AWSLambdaMiddleware_bodyToBase64_withcontent
 func Test_AWSLambdaMiddleware_bodyToBase64_withcontent(t *testing.T) {
 	// application/zip
 	expected := "UEsDBA=="


### PR DESCRIPTION
Updates invokeFunction to parse lambda error responses, log the error,
and return a 502.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
